### PR TITLE
Support missing tiles from mapbox API

### DIFF
--- a/label_maker_dask/main.py
+++ b/label_maker_dask/main.py
@@ -41,7 +41,7 @@ def tile_to_label(tile: Tile, ml_type: str, classes: Dict, label_source: str):
         tile_data = mapbox_vector_tile.decode(r.content)
     except:
         """It is possible to get empty vector tile response."""
-        tile_data = None
+        tile_data = {}
     label = get_label(tile_data, classes, ml_type)
 
     return (tile, label)

--- a/label_maker_dask/main.py
+++ b/label_maker_dask/main.py
@@ -35,10 +35,13 @@ def tile_to_label(tile: Tile, ml_type: str, classes: Dict, label_source: str):
     """
 
     url = label_source.format(x=tile.x, y=tile.y, z=tile.z)
-    r = requests.get(url)
-    r.raise_for_status()
-
-    tile_data = mapbox_vector_tile.decode(r.content)
+    try:
+        r = requests.get(url)
+        r.raise_for_status()   
+        tile_data = mapbox_vector_tile.decode(r.content)
+    except:
+        """It is possible to get empty vector tile response."""
+        tile_data = None
     label = get_label(tile_data, classes, ml_type)
 
     return (tile, label)


### PR DESCRIPTION
I have created a vector tile data set using tippecanoe and published it on mapbox tiles.

However, when there is no tile the return result breaks.

This change just handles this case.